### PR TITLE
Ensure compatibility with PG16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        pg-version: [11, 12, 13, 14, 15]
+        pg-version: [11, 12, 13, 14, 15, 16]
     steps:
       - id: install
         run: |

--- a/src/aiven_gatekeeper.h
+++ b/src/aiven_gatekeeper.h
@@ -13,6 +13,7 @@
 #define PG11_GTE (PG_VERSION_NUM >= 110000)
 #define PG13_GTE (PG_VERSION_NUM >= 130000)
 #define PG14_GTE (PG_VERSION_NUM >= 140000)
+#define PG16_GTE (PG_VERSION_NUM >= 160000)
 
 /* The process_utility_hook function changed in PG13 and again in PG14
  * versions from introduction (PG9) through PG12 have the same 7 argument structure


### PR DESCRIPTION
PG16 moved the columns being accessed or affected outside of the nodes to the root and only provides an index back to the `List` of entries. Use that to gather the columns.


