### PR TITLE
fix: remove unnecessary list_free

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -211,11 +211,10 @@ allow_granted_roles(List *addroleto)
         result = allow_grant_or_alter_role(role_member_oid);
         if (result != NULL)
         {
-            list_free(addroleto);
             elog(ERROR, "%s", result);
+            return;
         }
     }
-    list_free(addroleto);
 }
 
 static char *


### PR DESCRIPTION
# About this change - What it does

Using list_free on addroleto would lead to crashes when trying to use `CREATE ROLE ... WITH IN ROLE ...` in a function and the new role_name was longer than 4 characters

Resolves: SA-222

# Why this way

The `list_free` is unnecessary. Adds a `return`, that shouldn't be needed but exists to show that `elog()` should terminate execution.
