### PR TITLE
SqlBody variable could have been used uninitialized.

### DIFF
--- a/src/aiven_gatekeeper.c
+++ b/src/aiven_gatekeeper.c
@@ -269,7 +269,7 @@ gatekeeper_checks(PROCESS_UTILITY_PARAMS)
     char *funcLang;
     int i;
     bool checkBody;
-    char *sqlBody;
+    char *sqlBody = "";
     char *result;
 
     /* if the agent is disabled, skip all checks */


### PR DESCRIPTION
<!-- All contributors please complete these sections, including maintainers -->
# About this change - What it does

<!-- Provide a small sentence that summarizes the change. -->

<!-- Provide the issue number below if it exists. -->
Resolves: #xxxxx

# Why this way

<!-- Provide a small explanation on why this is the approach you took for solving this problem. -->

